### PR TITLE
Update Terraform modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ module "iam" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14 |
 
 ## Providers
 
@@ -32,17 +32,17 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_iam_account"></a> [iam\_account](#module\_iam\_account) | terraform-aws-modules/iam/aws//modules/iam-account | ~> 4.24 |
-| <a name="module_iam_group_admins_with_policies"></a> [iam\_group\_admins\_with\_policies](#module\_iam\_group\_admins\_with\_policies) | terraform-aws-modules/iam/aws//modules/iam-group-with-policies | ~> 3.0 |
-| <a name="module_iam_user_jackstockley"></a> [iam\_user\_jackstockley](#module\_iam\_user\_jackstockley) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 3.0 |
-| <a name="module_iam_user_jakemulley"></a> [iam\_user\_jakemulley](#module\_iam\_user\_jakemulley) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 3.0 |
-| <a name="module_iam_user_jasonbirchall"></a> [iam\_user\_jasonbirchall](#module\_iam\_user\_jasonbirchall) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 3.0 |
-| <a name="module_iam_user_kops"></a> [iam\_user\_kops](#module\_iam\_user\_kops) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 3.0 |
-| <a name="module_iam_user_paulwyborn"></a> [iam\_user\_paulwyborn](#module\_iam\_user\_paulwyborn) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 3.0 |
-| <a name="module_iam_user_poornimakrishnasamy"></a> [iam\_user\_poornimakrishnasamy](#module\_iam\_user\_poornimakrishnasamy) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 3.0 |
-| <a name="module_iam_user_sablumiah"></a> [iam\_user\_sablumiah](#module\_iam\_user\_sablumiah) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 3.0 |
-| <a name="module_iam_user_stevemarshall"></a> [iam\_user\_stevemarshall](#module\_iam\_user\_stevemarshall) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 3.0 |
-| <a name="module_iam_user_stevewilliams"></a> [iam\_user\_stevewilliams](#module\_iam\_user\_stevewilliams) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 3.0 |
-| <a name="module_iam_user_vijay_veeranki"></a> [iam\_user\_vijay\_veeranki](#module\_iam\_user\_vijay\_veeranki) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 3.0 |
+| <a name="module_iam_group_admins_with_policies"></a> [iam\_group\_admins\_with\_policies](#module\_iam\_group\_admins\_with\_policies) | terraform-aws-modules/iam/aws//modules/iam-group-with-policies | ~> 4.24 |
+| <a name="module_iam_user_jackstockley"></a> [iam\_user\_jackstockley](#module\_iam\_user\_jackstockley) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
+| <a name="module_iam_user_jakemulley"></a> [iam\_user\_jakemulley](#module\_iam\_user\_jakemulley) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
+| <a name="module_iam_user_jasonbirchall"></a> [iam\_user\_jasonbirchall](#module\_iam\_user\_jasonbirchall) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
+| <a name="module_iam_user_kops"></a> [iam\_user\_kops](#module\_iam\_user\_kops) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
+| <a name="module_iam_user_paulwyborn"></a> [iam\_user\_paulwyborn](#module\_iam\_user\_paulwyborn) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
+| <a name="module_iam_user_poornimakrishnasamy"></a> [iam\_user\_poornimakrishnasamy](#module\_iam\_user\_poornimakrishnasamy) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
+| <a name="module_iam_user_sablumiah"></a> [iam\_user\_sablumiah](#module\_iam\_user\_sablumiah) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
+| <a name="module_iam_user_stevemarshall"></a> [iam\_user\_stevemarshall](#module\_iam\_user\_stevemarshall) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
+| <a name="module_iam_user_stevewilliams"></a> [iam\_user\_stevewilliams](#module\_iam\_user\_stevewilliams) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
+| <a name="module_iam_user_vijay_veeranki"></a> [iam\_user\_vijay\_veeranki](#module\_iam\_user\_vijay\_veeranki) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -10,21 +10,21 @@ module "iam_account" {
 # CP Team
 module "iam_group_admins_with_policies" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-group-with-policies"
-  version = "~> 3.0"
+  version = "~> 4.24"
 
   name = "admins"
 
   group_users = [
-    module.iam_user_vijay_veeranki.this_iam_user_name,
-    module.iam_user_poornimakrishnasamy.this_iam_user_name,
-    module.iam_user_paulwyborn.this_iam_user_name,
-    module.iam_user_kops.this_iam_user_name,
-    module.iam_user_sablumiah.this_iam_user_name,
-    module.iam_user_jasonbirchall.this_iam_user_name,
-    module.iam_user_stevemarshall.this_iam_user_name,
-    module.iam_user_jackstockley.this_iam_user_name,
-    module.iam_user_stevewilliams.this_iam_user_name,
-    module.iam_user_jakemulley.this_iam_user_name
+    module.iam_user_vijay_veeranki.iam_user_name,
+    module.iam_user_poornimakrishnasamy.iam_user_name,
+    module.iam_user_paulwyborn.iam_user_name,
+    module.iam_user_kops.iam_user_name,
+    module.iam_user_sablumiah.iam_user_name,
+    module.iam_user_jasonbirchall.iam_user_name,
+    module.iam_user_stevemarshall.iam_user_name,
+    module.iam_user_jackstockley.iam_user_name,
+    module.iam_user_stevewilliams.iam_user_name,
+    module.iam_user_jakemulley.iam_user_name
   ]
 
   custom_group_policy_arns = [
@@ -34,7 +34,7 @@ module "iam_group_admins_with_policies" {
 
 module "iam_user_vijay_veeranki" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "~> 3.0"
+  version = "4.17.1"
 
   name                          = "VijayVeeranki"
   force_destroy                 = true
@@ -44,7 +44,7 @@ module "iam_user_vijay_veeranki" {
 
 module "iam_user_poornimakrishnasamy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "~> 3.0"
+  version = "4.17.1"
 
   name                          = "PoornimaKrishnasamy"
   force_destroy                 = true
@@ -53,7 +53,7 @@ module "iam_user_poornimakrishnasamy" {
 }
 module "iam_user_paulwyborn" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "~> 3.0"
+  version = "4.17.1"
 
   name                          = "paulwyborn"
   force_destroy                 = true
@@ -63,7 +63,7 @@ module "iam_user_paulwyborn" {
 
 module "iam_user_kops" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "~> 3.0"
+  version = "4.17.1"
 
   name                          = "kops"
   force_destroy                 = true
@@ -73,7 +73,7 @@ module "iam_user_kops" {
 
 module "iam_user_sablumiah" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "~> 3.0"
+  version = "4.17.1"
 
   name                          = "SabluMiah"
   force_destroy                 = true
@@ -83,7 +83,7 @@ module "iam_user_sablumiah" {
 
 module "iam_user_jasonbirchall" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "~> 3.0"
+  version = "4.17.1"
 
   name                          = "jasonBirchall"
   force_destroy                 = true
@@ -93,7 +93,7 @@ module "iam_user_jasonbirchall" {
 
 module "iam_user_stevemarshall" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "~> 3.0"
+  version = "4.17.1"
 
   name                          = "SteveMarshall"
   force_destroy                 = true
@@ -103,7 +103,7 @@ module "iam_user_stevemarshall" {
 
 module "iam_user_jackstockley" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "~> 3.0"
+  version = "4.17.1"
 
   name                          = "JackStockley"
   force_destroy                 = true
@@ -113,7 +113,7 @@ module "iam_user_jackstockley" {
 
 module "iam_user_stevewilliams" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "~> 3.0"
+  version = "4.17.1"
 
   name                          = "SteveWilliams"
   force_destroy                 = true
@@ -123,7 +123,7 @@ module "iam_user_stevewilliams" {
 
 module "iam_user_jakemulley" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "~> 3.0"
+  version = "4.17.1"
 
   name                          = "JakeMulley"
   force_destroy                 = true

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,5 +1,5 @@
 module "iam" {
   source = "../../"
 
-  aws_account_name       = "test-account"
+  aws_account_name = "test-account"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,3 @@
-
 variable "aws_account_name" {
-    type = string
+  type = string
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">0.13"
+  required_version = ">=0.14"
 }


### PR DESCRIPTION
This PR updates the `terraform-aws-modules/iam` modules to v4, which are no-op changes.

The `iam-user` module is pinned at `4.17.1`, as `4.17.2` introduces the use of `sensitive()`, which requires Terraform 0.15 (tracked in ministryofjustice/cloud-platform#3984).