### PR TITLE
Remove IAM user for kops

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ No providers.
 | <a name="module_iam_user_jackstockley"></a> [iam\_user\_jackstockley](#module\_iam\_user\_jackstockley) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 | <a name="module_iam_user_jakemulley"></a> [iam\_user\_jakemulley](#module\_iam\_user\_jakemulley) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 | <a name="module_iam_user_jasonbirchall"></a> [iam\_user\_jasonbirchall](#module\_iam\_user\_jasonbirchall) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
-| <a name="module_iam_user_kops"></a> [iam\_user\_kops](#module\_iam\_user\_kops) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 | <a name="module_iam_user_paulwyborn"></a> [iam\_user\_paulwyborn](#module\_iam\_user\_paulwyborn) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 | <a name="module_iam_user_poornimakrishnasamy"></a> [iam\_user\_poornimakrishnasamy](#module\_iam\_user\_poornimakrishnasamy) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 | <a name="module_iam_user_sablumiah"></a> [iam\_user\_sablumiah](#module\_iam\_user\_sablumiah) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,6 @@ module "iam_group_admins_with_policies" {
     module.iam_user_vijay_veeranki.iam_user_name,
     module.iam_user_poornimakrishnasamy.iam_user_name,
     module.iam_user_paulwyborn.iam_user_name,
-    module.iam_user_kops.iam_user_name,
     module.iam_user_sablumiah.iam_user_name,
     module.iam_user_jasonbirchall.iam_user_name,
     module.iam_user_stevemarshall.iam_user_name,
@@ -56,16 +55,6 @@ module "iam_user_paulwyborn" {
   version = "4.17.1"
 
   name                          = "paulwyborn"
-  force_destroy                 = true
-  create_iam_user_login_profile = false
-  create_iam_access_key         = false
-}
-
-module "iam_user_kops" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "4.17.1"
-
-  name                          = "kops"
   force_destroy                 = true
   create_iam_user_login_profile = false
   create_iam_access_key         = false


### PR DESCRIPTION
This PR removes the IAM user `kops` from the Cloud Platform AWS account.

It has had no activity in the past 400 days, and has not had not have active access keys since 2019.