### PR TITLE
Remove IAM user for SteveMarshall

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ No providers.
 | <a name="module_iam_user_paulwyborn"></a> [iam\_user\_paulwyborn](#module\_iam\_user\_paulwyborn) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 | <a name="module_iam_user_poornimakrishnasamy"></a> [iam\_user\_poornimakrishnasamy](#module\_iam\_user\_poornimakrishnasamy) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 | <a name="module_iam_user_sablumiah"></a> [iam\_user\_sablumiah](#module\_iam\_user\_sablumiah) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
-| <a name="module_iam_user_stevemarshall"></a> [iam\_user\_stevemarshall](#module\_iam\_user\_stevemarshall) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 | <a name="module_iam_user_stevewilliams"></a> [iam\_user\_stevewilliams](#module\_iam\_user\_stevewilliams) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 | <a name="module_iam_user_vijay_veeranki"></a> [iam\_user\_vijay\_veeranki](#module\_iam\_user\_vijay\_veeranki) | terraform-aws-modules/iam/aws//modules/iam-user | 4.17.1 |
 

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,6 @@ module "iam_group_admins_with_policies" {
     module.iam_user_kops.iam_user_name,
     module.iam_user_sablumiah.iam_user_name,
     module.iam_user_jasonbirchall.iam_user_name,
-    module.iam_user_stevemarshall.iam_user_name,
     module.iam_user_jackstockley.iam_user_name,
     module.iam_user_stevewilliams.iam_user_name,
     module.iam_user_jakemulley.iam_user_name
@@ -86,16 +85,6 @@ module "iam_user_jasonbirchall" {
   version = "4.17.1"
 
   name                          = "jasonBirchall"
-  force_destroy                 = true
-  create_iam_user_login_profile = false
-  create_iam_access_key         = false
-}
-
-module "iam_user_stevemarshall" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
-  version = "4.17.1"
-
-  name                          = "SteveMarshall"
   force_destroy                 = true
   create_iam_user_login_profile = false
   create_iam_access_key         = false


### PR DESCRIPTION
This PR removes the IAM user `SteveMarshall` from the Cloud Platform AWS account.

It has had no activity in the past 972 days, and has no active access keys.