### PR TITLE
Add gh action to push new terraform module releases to our API

### DIFF
--- a/.github/workflows/push-terraform-module-version.yaml
+++ b/.github/workflows/push-terraform-module-version.yaml
@@ -1,0 +1,16 @@
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  push-terraform-module-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ministryofjustice/cloud-platform-environments/cmd/push-terraform-module-version@main
+        env:
+          API_URL: ${{ vars.TERRAFORM_MODULE_VERSIONS_API_URL }}
+          API_KEY: ${{ secrets.TERRAFORM_MODULE_VERSIONS_API_KEY }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          UPDATED_MODULE_VERSION: ${{ github.ref_name }}


### PR DESCRIPTION
Programatically add a new gh action that will post new releases/ versions to our API